### PR TITLE
Refresh the version manifest whenever a version isn't found

### DIFF
--- a/cmd/mc/install.go
+++ b/cmd/mc/install.go
@@ -14,8 +14,6 @@ import (
 
 //todo tab completions
 
-var triedToUpdate = false
-
 type installOpts struct {
 	app *cli.App
 
@@ -55,17 +53,8 @@ func (o *installOpts) validateArgs(cmd *cobra.Command, args []string) (err error
 	// Validate version arg (0)
 	versionManager := o.app.VersionManager()
 	if o.version, err = versionManager.FindVanilla(args[0]); errors.Is(err, game.ErrUnknownVersion) {
-		if triedToUpdate {
-			return fmt.Errorf("%w: %s", err, args[0])
-		}
-		fmt.Println("Couldn't find version: ", args[0], ", refreshing manfiest")
-		triedToUpdate = true
-		if err := versionManager.UpdateManifest(); err != nil {
-			return err
-		}
-		return o.validateArgs(cmd, args)
+		return fmt.Errorf("%w: %s", err, args[0])
 	}
-	triedToUpdate = false
 
 	// Validate name arg (1, optional)
 	if len(args) > 1 && !profile.IsValidName(args[1]) {
@@ -81,15 +70,7 @@ func (o *installOpts) validateArgs(cmd *cobra.Command, args []string) (err error
 
 		o.version, err = versionManager.FindFabric(args[0], o.fabricLoader)
 		if errors.Is(err, game.ErrUnknownFabricVersion) {
-			if triedToUpdate {
-				return fmt.Errorf("%w: %s", err, args[0])
-			}
-			fmt.Println("Couldn't find fabric for version: ", args[0], ", refreshing manfiest")
-			triedToUpdate = true
-			if err := versionManager.UpdateManifest(); err != nil {
-				return err
-			}
-			return o.validateArgs(cmd, args)
+			return fmt.Errorf("%w: %s", err, args[0])
 		}
 		if errors.Is(err, game.ErrUnknownFabricLoader) {
 			return fmt.Errorf("%w: %s", err, o.fabricLoader)

--- a/internal/pkg/game/version.go
+++ b/internal/pkg/game/version.go
@@ -31,7 +31,7 @@ var (
 	ErrUnknownVersion       = errors.New("unknown version")
 	ErrUnknownFabricVersion = errors.New("unknown fabric version")
 	ErrUnknownFabricLoader  = errors.New("unknown fabric loader")
-	TriedToUpdate           = false
+	triedToUpdate           = false
 )
 
 type (
@@ -118,15 +118,15 @@ func NewVersionManager(dataDir string) (*VersionManager, error) {
 func (m *VersionManager) FindVanilla(name string) (*gameModel.VersionInfo, error) {
 	v, ok := m.manifestV2.Vanilla.Versions[strings.ToLower(name)]
 	if !ok {
-		if TriedToUpdate {
+		if triedToUpdate {
 			return nil, ErrUnknownVersion
 		}
-		TriedToUpdate = true
+		triedToUpdate = true
 		fmt.Println("Couldn't find version: ", name, ", refreshing manfiest")
 		m.updateManifest()
 		return m.FindVanilla(name)
 	}
-	TriedToUpdate = false
+	triedToUpdate = false
 	return v, nil
 }
 
@@ -137,15 +137,15 @@ func (m *VersionManager) FindFabric(name, loader string) (*gameModel.VersionInfo
 
 	partial, ok := m.manifestV2.Fabric.Versions[strings.ToLower(name)]
 	if !ok {
-		if TriedToUpdate {
+		if triedToUpdate {
 			return nil, ErrUnknownFabricVersion
 		}
-		TriedToUpdate = true
+		triedToUpdate = true
 		fmt.Println("Couldn't find fabric for version: ", name, ", refreshing manfiest")
 		m.updateManifest()
 		return m.FindFabric(name, loader)
 	}
-	TriedToUpdate = false
+	triedToUpdate = false
 
 	return &gameModel.VersionInfo{
 		Id:     fmt.Sprintf(partial.Id, loader),

--- a/internal/pkg/game/version.go
+++ b/internal/pkg/game/version.go
@@ -122,7 +122,6 @@ func (m *VersionManager) FindVanilla(name string) (*gameModel.VersionInfo, error
 			return nil, ErrUnknownVersion
 		}
 		m.triedToUpdate = true
-		fmt.Println("Couldn't find version: ", name, ", refreshing manfiest")
 		m.updateManifest()
 		return m.FindVanilla(name)
 	}
@@ -141,7 +140,6 @@ func (m *VersionManager) FindFabric(name, loader string) (*gameModel.VersionInfo
 			return nil, ErrUnknownFabricVersion
 		}
 		m.triedToUpdate = true
-		fmt.Println("Couldn't find fabric for version: ", name, ", refreshing manfiest")
 		m.updateManifest()
 		return m.FindFabric(name, loader)
 	}

--- a/internal/pkg/game/version.go
+++ b/internal/pkg/game/version.go
@@ -92,7 +92,7 @@ func NewVersionManager(dataDir string) (*VersionManager, error) {
 	m := &VersionManager{cacheFile: cacheFile}
 
 	if _, err := os.Stat(cacheFile); errors.Is(err, fs.ErrNotExist) {
-		if err := m.updateManifest(); err != nil {
+		if err := m.UpdateManifest(); err != nil {
 			return nil, err
 		}
 	} else {
@@ -148,7 +148,7 @@ func (m *VersionManager) FabricLoaderExists(name string) bool {
 	return ok
 }
 
-func (m *VersionManager) updateManifest() error {
+func (m *VersionManager) UpdateManifest() error {
 	var result VersionManifestV2
 	result.LastUpdated = time.Now()
 	result.Vanilla.Versions = make(map[string]*gameModel.VersionInfo)


### PR DESCRIPTION
This PR makes it so the version manifest is redownloaded whenever a version isn't found, this makes it easier to download new versions of Minecraft when they are released.